### PR TITLE
Default ruamel.yaml.clib outdated

### DIFF
--- a/Software/Python/requirements.txt
+++ b/Software/Python/requirements.txt
@@ -2,4 +2,4 @@ tornado>=6.3.3
 argparse
 pyserial==3.5
 ruamel.yaml==0.17.21
-ruamel.yaml.clib==0.2.7
+ruamel.yaml.clib==0.2.14


### PR DESCRIPTION
referenced ruamel.yaml.clib package was failing to install, stepped through the minimum versions (0.2.7, 0.2.8 -> 0.2.14) before a successful install